### PR TITLE
Fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dom-notifications",
   "description": "atom-inspired notifications",
   "main": "index.js",
-  "style": "notification.css",
+  "style": "notifications.css",
   "scripts": {
     "test": "standard",
     "deploy": "browserify example/example.js -o example/bundle.js && gh-pages -d example",


### PR DESCRIPTION
Unable to import styles with `sheetify` (or similar) as of now. There's a mismatch in the filename in `package.json#style` and `notifications.css`.